### PR TITLE
Build documentation with jupyter book version 0.15

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -61,7 +61,7 @@ sphinx:
       - transformers
       - webrtcvad
     autosummary_ignore_module_all: False
-    execution_show_tb: True
+    nb_execution_show_tb: True
     # napoleon extension config
     napoleon_use_ivar: True
     napoleon_use_param: True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,14 +192,13 @@ cov = [
 
 [tool.hatch.envs.docs]
 dependencies = [
-  "jupyter-book==0.13.*",
+  "jupyter-book==0.15.*",
   "matplotlib",
   "pandas>=1.4",
   "spacy>=3.4",
-  "sphinx>=4.3.3",
-  "sphinxcontrib-mermaid>=0.8",
   "sphinx-autobuild",
   "sphinx-toolbox",
+  "sphinxcontrib-mermaid",
 ]
 features = [
   "metrics-ner",


### PR DESCRIPTION
Should fix (part of) the problem with long builds, which currently prevents from deploying on RTD due to timeouts. 