### PR TITLE
DOC : Add example for the evaluation of multiple entity matchers 

### DIFF
--- a/docs/examples/ner_evaluation/config_gpt3.cfg
+++ b/docs/examples/ner_evaluation/config_gpt3.cfg
@@ -1,0 +1,47 @@
+[paths]
+examples = "examples.json"
+
+[nlp]
+lang = "fr"
+pipeline = ["llm"]
+
+[components]
+
+[components.llm]
+factory = "llm"
+
+[components.llm.task]
+@llm_tasks = "spacy.NER.v3"
+labels = ["Anatomie", "Appareil", "Organisme", "Médicament", "Objet", "Pathologie", "Phénomène", "Physiologie", "Procédure", "Région"]
+description = Les entités ne doivent strictement pas faire plus 2 mots de longueur.
+              Tu dois faire le plus d entités possible.
+              Tu dois faire des entités le plus petit possible.
+              Les pronoms, les articles, les prépositions, les contraction ne font pas partie des entités.
+              Les entités à privilégier sont Appareil, Médicament et Pathologie
+              
+[components.llm.task.label_definitions]
+Anatomie = "Représente toute structure anatomique, organe, ou région du corps humain."
+Médicament = "Comprend médicaments, substances chimiques, enzymes, et matériaux biomédicaux."
+Appareil = "Englobe tout dispositif médical, d'administration de médicaments ou de recherche."
+Pathologie = "Inclut les anomalies acquises, congénitales, maladies, syndromes, et dysfonctionnements."
+Région = "Représente toute zone géographique."
+Organisme = "Comprend groupes d'âge, animaux, plantes, micro-organismes, et virus."
+Objet = "Englobe entités, aliments, objets manufacturés, et substances."
+Phénomène = "Inclut fonctions biologiques, effets environnementaux, phénomènes causés par l'homme ou naturels."
+Physiologie = "Ensemble des fonctions cellulaires, génétiques, mentales, moléculaires, et physiologiques."
+Procédure = "Comprend procédures de diagnostic, activités éducatives, soins de santé, et techniques de recherche."
+
+[components.llm.task.examples]
+@misc = "spacy.FewShotReader.v1"
+path = "${paths.examples}"
+
+[components.llm.model]
+@llm_models = "spacy.GPT-3-5.v3"
+
+
+
+
+
+
+
+

--- a/docs/examples/ner_evaluation/config_gpt4.cfg
+++ b/docs/examples/ner_evaluation/config_gpt4.cfg
@@ -1,0 +1,47 @@
+[paths]
+examples = "examples.json"
+
+[nlp]
+lang = "fr"
+pipeline = ["llm"]
+
+[components]
+
+[components.llm]
+factory = "llm"
+
+[components.llm.task]
+@llm_tasks = "spacy.NER.v3"
+labels = ["Anatomie", "Appareil", "Organisme", "Médicament", "Objet", "Pathologie", "Phénomène", "Physiologie", "Procédure", "Région"]
+description = Les entités ne doivent strictement pas faire plus 2 mots de longueur.
+              Tu dois faire le plus d entités possible.
+              Tu dois faire des entités le plus petit possible.
+              Les pronoms, les articles, les prépositions, les contraction ne font pas partie des entités.
+              Les entités à privilégier sont Appareil, Médicament et Pathologie
+              
+[components.llm.task.label_definitions]
+Anatomie = "Représente toute structure anatomique, organe, ou région du corps humain."
+Médicament = "Comprend médicaments, substances chimiques, enzymes, et matériaux biomédicaux."
+Appareil = "Englobe tout dispositif médical, d'administration de médicaments ou de recherche."
+Pathologie = "Inclut les anomalies acquises, congénitales, maladies, syndromes, et dysfonctionnements."
+Région = "Représente toute zone géographique."
+Organisme = "Comprend groupes d'âge, animaux, plantes, micro-organismes, et virus."
+Objet = "Englobe entités, aliments, objets manufacturés, et substances."
+Phénomène = "Inclut fonctions biologiques, effets environnementaux, phénomènes causés par l'homme ou naturels."
+Physiologie = "Ensemble des fonctions cellulaires, génétiques, mentales, moléculaires, et physiologiques."
+Procédure = "Comprend procédures de diagnostic, activités éducatives, soins de santé, et techniques de recherche."
+
+[components.llm.task.examples]
+@misc = "spacy.FewShotReader.v1"
+path = "${paths.examples}"
+
+[components.llm.model]
+@llm_models = "spacy.GPT-4.v3"
+
+
+
+
+
+
+
+

--- a/docs/examples/ner_evaluation/examples.json
+++ b/docs/examples/ner_evaluation/examples.json
@@ -1,0 +1,511 @@
+[
+  {
+    "text": "Des commentaires spécifiques et des recommandations de prudence concernant la méningite , l ’ élévation des taux de créatine phosphokinase et les effets indésirables sur le SNC figurent à la rubrique 4 . 4 .",
+    "spans": [
+      {
+        "text": "méningite",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle désigne une maladie ou une inflammation des membranes qui entourent le cerveau et la moelle épinière."
+      },
+      {
+        "text": "créatine phosphokinase",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " cette enzyme est souvent utilisée comme marqueur de la toxicité d'un médicament sur les muscles."
+      },
+      {
+        "text": "effets indésirables",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à des problèmes médicaux ou des complications liés à un traitement ou à une condition spécifique."
+      },
+      {
+        "text": "recommandations",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une instruction ou d'une démarche à suivre."
+      },
+      {
+        "text": "SNC",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " il s'agit d'une référence à la structure du système nerveux central."
+      }
+    ]
+  },
+  {
+    "text": "Dans les études de perfusion intraveineuse , des volontaires sains de sexe masculin ont reçu le ziconotide à des doses atteignant 70 000 µg / jour ou 3 , 200 fois la dose journalière maximale recommandée par voie intrarachidienne .",
+    "spans": [
+      {
+        "text": "intrarachidienne",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à une localisation spécifique dans le corps humain."
+      },
+      {
+        "text": "ziconotide",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " c'est le nom du médicament mentionné dans la phrase."
+      },
+      {
+        "text": "recommandée",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une indication ou d'une instruction liée à une procédure de dosage."
+      },
+      {
+        "text": "perfusion",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " cela décrit une méthode spécifique utilisée dans les études sur l'administration intraveineuse du médicament."
+      },
+      {
+        "text": "sexe masculin",
+        "is_entity": true,
+        "label": "Physiologie",
+        "reason": " il s'agit d'une caractéristique biologique liée à la physiologie humaine."
+      },
+      {
+        "text": "études",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une description des activités de recherche ou d'expérimentation menées dans le cadre de cette étude."
+      },
+      {
+        "text": "volontaires",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " elle fait référence à un groupe spécifique de personnes mentionnées dans le texte."
+      }
+    ]
+  },
+  {
+    "text": "Une hypotension orthostatique a été observée chez presque tous les sujets ayant reçu de fortes doses intraveineuses de ziconotide .",
+    "spans": [
+      {
+        "text": "ziconotide",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " il s'agit du nom d'un médicament mentionné dans la phrase."
+      },
+      {
+        "text": "hypotension orthostatique",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " il s'agit d'une condition médicale qui décrit une baisse significative de la pression artérielle lors du passage de la position allongée à la position debout."
+      },
+      {
+        "text": "sujets",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " cette partie de phrase fait référence aux individus concernés par l'observation mentionnée précédemment."
+      }
+    ]
+  },
+  {
+    "text": "La posologie maximale recommandée par voie intrarachidienne est de 21 , 6 µg / jour .",
+    "spans": [
+      {
+        "text": "recommandée",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une instruction ou d'une directive."
+      },
+      {
+        "text": "intrarachidienne",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à une localisation anatomique spécifique."
+      }
+    ]
+  },
+  {
+    "text": "Dans les études cliniques , la dose maximale prévue de ziconotide administré par voie intrarachidienne était de 912 µg / jour après une augmentation posologique sur 7 jours .",
+    "spans": [
+      {
+        "text": "intrarachidienne",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à la localisation de l'administration de la dose maximale prévue de ziconotide, qui se fait dans l'espace intrarachidien."
+      },
+      {
+        "text": "administré",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " elle indique une action spécifique réalisée dans le cadre d'une procédure médicale."
+      },
+      {
+        "text": "ziconotide",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " il s'agit du nom d'un médicament spécifique mentionné dans le texte."
+      },
+      {
+        "text": "études cliniques",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une mention spécifique à une méthode d'investigation ou de recherche utilisée dans le texte."
+      }
+    ]
+  },
+  {
+    "text": "La plupart des patients sous observation ont récupéré dans les 24 heures suivant l",
+    "spans": [
+      {
+        "text": "observation",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une étude ou surveillance relative à la santé ou aux maladies."
+      },
+      {
+        "text": "récupéré",
+        "is_entity": true,
+        "label": "Physiologie",
+        "reason": " cela relève du fonctionnement normal du corps humain."
+      },
+      {
+        "text": "patients",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " elle se réfère à un groupe d'individus qui sont observés dans le contexte d'une étude ou d'une recherche médicale."
+      }
+    ]
+  },
+  {
+    "text": "L ’ Agence européenne du médicament ( EMEA ) réévaluera chaque année toute nouvelle information qui pourrait être fournie , et si nécessaire cet RCP sera mis à jour .",
+    "spans": [
+      {
+        "text": "médicament",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " il s'agit de l'objet principal du texte et de l'information centrale liée à l'Agence européenne du médicament."
+      },
+      {
+        "text": "réévaluera",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " cela décrit une action spécifique et une méthode de travail utilisée par l'Agence européenne du médicament."
+      }
+    ]
+  },
+  {
+    "text": "De nombreux patients répondant au traitement obtiennent une analgésie quasi-maximale dans les heures suivant l",
+    "spans": [
+      {
+        "text": "traitement",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une action ou d'une méthode spécifique mise en place pour soigner les patients."
+      },
+      {
+        "text": "patients",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " elle fait référence à un groupe d'individus."
+      }
+    ]
+  },
+  {
+    "text": "Les effets indésirables neurologiques , notamment les sensations vertigineuses , les nausées et les troubles de la démarche semblent corrélées avec les concentrations céphalo-rachidiennes mais aucune relation définitive n",
+    "spans": [
+      {
+        "text": "nausées",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elles désignent des symptômes qui peuvent être associés à une maladie ou un trouble médical."
+      },
+      {
+        "text": "neurologiques",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à une catégorie spécifique de troubles liés au système nerveux."
+      },
+      {
+        "text": "troubles de la démarche",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle décrit une altération fonctionnelle ou un problème de santé lié à la manière de marcher."
+      },
+      {
+        "text": "sensations vertigineuses",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elles sont des symptômes inhabituels pouvant indiquer la présence d'une maladie ou d'un trouble médical."
+      },
+      {
+        "text": "effets indésirables",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à des troubles ou symptômes indésirables provenant d'une maladie ou d'une condition médicale."
+      }
+    ]
+  },
+  {
+    "text": "Pour limiter la survenue d ’ effets indésirables graves , il est recommandé de ne pas dépasser 21 , 6 µg / jour .",
+    "spans": [
+      {
+        "text": "effets indésirables",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " ils peuvent être liés à des troubles de santé."
+      },
+      {
+        "text": "recommandé",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'une instruction ou d'une recommandation donnée aux personnes concernées."
+      }
+    ]
+  },
+  {
+    "text": "Cependant , dans les études cliniques , on a observé que les patients qui tolèrent des doses de 21 , 6 µg / jour après une augmentation progressive des",
+    "spans": [
+      {
+        "text": "patients",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " elle se réfère à des individus vivants étudiés dans le contexte des essais cliniques."
+      },
+      {
+        "text": "études cliniques",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " elle décrit une méthode ou un processus utilisé dans la recherche ou l'analyse médicale."
+      },
+      {
+        "text": "tolèrent",
+        "is_entity": true,
+        "label": "Physiologie",
+        "reason": " elle indique que cette capacité à supporter des doses de médicaments est liée au fonctionnement physique du corps."
+      }
+    ]
+  },
+  {
+    "text": "8 doses pendant une période de 3 à 4 semaines , tolèrent généralement des doses plus élevées , pouvant atteindre 48 , 0 µg / jour .",
+    "spans": [
+      {
+        "text": "tolèrent",
+        "is_entity": true,
+        "label": "Physiologie",
+        "reason": " cela concerne la capacité du corps à supporter des doses plus élevées."
+      }
+    ]
+  },
+  {
+    "text": "Toutefois , compte tenu des données limitées disponibles , l ’ apparition d ’ une accoutumance ne peut être exclue .",
+    "spans": [
+      {
+        "text": "accoutumance",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une condition médicale ou une maladie."
+      }
+    ]
+  },
+  {
+    "text": "La perméabilité du cathéter intrarachidien doit être examinée en cas de nécessité d ’ une augmentation continue des doses de ziconotide n",
+    "spans": [
+      {
+        "text": "intrarachidien",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " cette partie spécifie le lieu d'implantation du cathéter."
+      },
+      {
+        "text": "cathéter",
+        "is_entity": true,
+        "label": "Appareil",
+        "reason": " il s'agit d'un instrument médical utilisé pour administrer le ziconotide."
+      },
+      {
+        "text": "ziconotide",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " il s'agit du nom d'un médicament spécifique mentionné dans le texte."
+      },
+      {
+        "text": "perméabilité",
+        "is_entity": true,
+        "label": "Phénomène",
+        "reason": " il s'agit d'un aspect ou d'un processus spécifique qui est observé ou décrit."
+      }
+    ]
+  },
+  {
+    "text": "Trois études cliniques du ziconotide intrarachidien contrôlées contre placebo ont été réalisées .",
+    "spans": [
+      {
+        "text": "placebo",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " cela fait référence à une substance utilisée à des fins thérapeutiques dans le cadre des études cliniques."
+      },
+      {
+        "text": "études cliniques",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " elles font référence à des recherches menées dans le cadre d'une méthodologie spécifique."
+      },
+      {
+        "text": "intrarachidien",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " cette expression fait référence à la localisation spécifique de l'administration du ziconotide dans la colonne vertébrale."
+      },
+      {
+        "text": "ziconotide",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " il s'agit du nom d'un médicament spécifique mentionné dans la phrase."
+      }
+    ]
+  },
+  {
+    "text": "Score EVA moyen à la fin du titrage de doses initial , en mm ( ET )",
+    "spans": [
+      {
+        "text": "EVA",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " il s'agit d'un indicateur utilisé dans une procédure de mesure."
+      }
+    ]
+  },
+  {
+    "text": "Placebo ( n = 86 )",
+    "spans": [
+      {
+        "text": "Placebo",
+        "is_entity": true,
+        "label": "Médicament",
+        "reason": " un placebo est une substance qui ressemble à un médicament mais qui ne contient pas de principe actif."
+      }
+    ]
+  },
+  {
+    "text": "L ’ étiologie de la douleur dans les études 95 - 001 ( douleur cancéreuse ) et 96 - 002 ( douleur non cancéreuse ) variait , incluant des douleurs osseuses ( n = 380 ), due principalement à des métastases osseuses ( n = 34 ), une myélopathie ( n = 38 ), dont la moitié présentait un traumatisme médullaire avec paralysie ( n = 19 ), neuropathie ( n = 79 ), radiculopathie ( n = 24 ), douleur médullaire ( n = 91 ) due principalement à l ’ échec d ’ une intervention chirurgicale au niveau dorsal ( n = 82 ) et autres étiologies ( n = 82 ).",
+    "spans": [
+      {
+        "text": "neuropathie",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " il s'agit d'une condition médicale caractérisée par des lésions ou des dysfonctionnements du système nerveux périphérique."
+      },
+      {
+        "text": "métastases osseuses",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle désigne une maladie liée à l'extension de cellules cancéreuses aux os."
+      },
+      {
+        "text": "douleur",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une condition médicale ou une affection susceptible de causer une souffrance ou un malaise physique."
+      },
+      {
+        "text": "myélopathie",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle désigne une affection au niveau de la moelle épinière."
+      },
+      {
+        "text": "médullaire",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à une localisation spécifique dans la moelle épinière."
+      },
+      {
+        "text": "douleur cancéreuse",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " il s'agit d'une condition médicale liée à la présence de cancer."
+      },
+      {
+        "text": "paralysie",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une condition médicale caractérisée par la perte partielle ou totale de la fonction motrice d'une ou de plusieurs parties du corps."
+      },
+      {
+        "text": "traumatisme",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " cette dernière fait référence à une condition médicale liée à une blessure physique."
+      },
+      {
+        "text": "douleur",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle décrit une condition médicale problématique liée à la santé."
+      },
+      {
+        "text": "douleur",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une condition médicale ou un trouble physique."
+      },
+      {
+        "text": "études",
+        "is_entity": true,
+        "label": "Procédure",
+        "reason": " elle décrit la procédure de recherche et d'analyse utilisée pour collecter et étudier les données concernant l'étiologie de la douleur dans les études."
+      },
+      {
+        "text": "cancéreuse",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle décrit une condition médicale relative au cancer."
+      },
+      {
+        "text": "intervention chirurgicale",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle fait référence à une procédure médicale liée à une pathologie."
+      },
+      {
+        "text": "médullaire",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " cette partie de phrase fait référence à une localisation anatomique précise, à savoir la moelle épinière."
+      },
+      {
+        "text": "dorsal",
+        "is_entity": true,
+        "label": "Anatomie",
+        "reason": " elle fait référence à une localisation spécifique du corps."
+      },
+      {
+        "text": "radiculopathie",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " cette expression désigne une maladie ou un trouble touchant les racines nerveuses de la moelle épinière."
+      },
+      {
+        "text": "douleurs osseuses",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle désigne une condition médicale liée aux os."
+      }
+    ]
+  },
+  {
+    "text": "Certains patients présentaient plusieurs causes de douleur .",
+    "spans": [
+      {
+        "text": "douleur",
+        "is_entity": true,
+        "label": "Pathologie",
+        "reason": " elle est causée par une certaine maladie ou condition médicale."
+      },
+      {
+        "text": "patients",
+        "is_entity": true,
+        "label": "Organisme",
+        "reason": " elle se réfère à un groupe de personnes ou d'individus appartenant à un organisme spécifique."
+      }
+    ]
+  }
+]

--- a/docs/examples/ner_evaluation/ner_evalution.md
+++ b/docs/examples/ner_evaluation/ner_evalution.md
@@ -14,13 +14,11 @@ kernelspec:
 ```{code-cell} ipython3
 from medkit.io.medkit_json import load_text_documents
 from medkit.core.text import TextDocument
-from medkit.text.segmentation import SentenceTokenizer
 from pathlib import Path
 from tqdm import tqdm
 from medkit.text.ner import UMLSMatcher
 from medkit.text.metrics.ner import SeqEvalEvaluator
 import pandas as pd
-from glob import glob
 from medkit.text.ner.hf_entity_matcher import HFEntityMatcher
 import torch
 from medkit.core import Pipeline, DocPipeline, PipelineStep
@@ -30,165 +28,101 @@ import os
 from medkit.core.text import Entity, Span
 from spacy import displacy
 from medkit.text.spacy.displacy_utils import medkit_doc_to_displacy
-import random
 from IPython.display import display, HTML
-import pandas as pd
+from typing import List 
 
 DEVICE = 0 if torch.cuda.is_available() else -1
 
+
+class GPT_NER:
+    def __init__(self, config, _open_ai_key, _name):
+        os.environ["OPENAI_API_KEY"] = _open_ai_key
+        self.nlp = assemble(config)
+        self.description = self.Description(_name)
+
+    def run(self, _raw_segment : []):
+        doc = self.nlp(_raw_segment[0].text)
+        gpt_remapping = { "Anatomie": "ANAT", "Médicament": "CHEM", "Appareil": "DEVI", "Pathologie": "DISO", "Région": "GEOG", "Organisme": "LIVB", "Objet": "OBJC", "Phénomène": "PHEN", "Physiologie": "PHYS", "Procédure": "PROC"}
+        predicted_entities = [Entity(label=gpt_remapping[ent.label_], text=ent.text, spans=[Span(ent.start_char, ent.end_char)]) for ent in doc.ents]
+
+        return predicted_entities
+    
+    class Description:
+        def __init__(self, _name):
+            self.name = _name
+
+#Mets en forme les résultats renvoyé par SeqEvalEvaluator
 def results_to_df(_results, _title):
     results_list = list(_results.items())
-    arranged_results = {}
-    arranged_results["Entities"] = ['P','R','F1']
-    arranged_results["all"] = [round(results_list[i][1],2) for i in [0,1,2]]
-    accuracy = round(results_list[4][1],2)
-    for i in range(5,len(results_list), 4):
+    arranged_results = {"Entities": ['P', 'R', 'F1'], 
+                        "all": [round(results_list[i][1], 2) for i in [0, 1, 2]]}
+    accuracy = round(results_list[4][1], 2)
+
+    for i in range(5, len(results_list), 4):
         key = results_list[i][0][:-10]
-        arranged_results[key] = [round(results_list[n][1],2) for n in [i,i+1,i+2]]
-    df = pd.DataFrame(arranged_results, index=[f"{_title} ({accuracy})",'','']).T
+        arranged_results[key] = [round(results_list[n][1], 2) for n in [i, i + 1, i + 2]]
+
+    df = pd.DataFrame(arranged_results, index=[f"{_title} ({accuracy})", '', '']).T
     return df
 
-def LLMNER(_text, _nlp):
-    doc = _nlp(_text)
-    
-    predicted_entities = []
+#Evalue les annotations de plusieurs outils de NER sur les documents fournis
+def eval(_docs, open_ai_key="", _labels_remapping = {"ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
+                                                     "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
 
-    gpt_remapping = {
-    "Anatomie": "ANAT",
-    "Médicament": "CHEM",
-    "Appareil": "DEVI",
-    "Pathologie": "DISO",
-    "Région": "GEOG",
-    "Organisme": "LIVB",
-    "Objet": "OBJC",
-    "Phénomène": "PHEN",
-    "Physiologie": "PHYS",
-    "Procédure": "PROC",
-    }
+    ners = []
+    ners.append(UMLSMatcher(umls_dir=Path.home() / "src/UMLS", cache_dir=".umls_cache", language="FRE", semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'], lowercase=True, normalize_unicode=True, name="umls_matcher", output_labels_by_semgroup=_labels_remapping))
+    ners.append(HFEntityMatcher(model="Thibeb/CamemBert_bio_generalized", name="drbert_matcher", device=DEVICE))
+    ners.append(HFEntityMatcher(model="Thibeb/DrBert_generalized", name="camembert_matcher", device=DEVICE))
+    if open_ai_key != "" : ners.append(GPT_NER("config_gpt.cfg", open_ai_key,_name='ChatGPT-3.5-turbo'))
 
-    for ent in doc.ents:
-        predicted_entities.append(Entity(
-            label=gpt_remapping[ent.label_],
-            text=ent.text,
-            spans=[Span(ent.start_char, ent.end_char)]
-        ))
-
-    return predicted_entities
-
-def eval(_docs, open_ai_key = "", _labels_remapping = {
-        "ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
-        "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
-
-    use_gpt = True if open_ai_key != "" else False
-    
-    if use_gpt:
-        os.environ["OPENAI_API_KEY"] = open_ai_key
-        nlp = assemble("config_gpt.cfg")
-
-    #Loading entity matchers
-    umls_matcher = UMLSMatcher(
-        umls_dir=Path.home() / "src/UMLS",
-        cache_dir=".umls_cache",
-        language="FRE",
-        semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'],
-        lowercase=True,
-        normalize_unicode=True,
-        name="umls_matcher",
-        output_labels_by_semgroup=_labels_remapping
-    )
-
-    drbert_matcher = HFEntityMatcher(model="Thibeb/CamemBert_bio_generalized", name="drbert_matcher", device=DEVICE)
-    camembert_matcher = HFEntityMatcher(model="Thibeb/DrBert_generalized", name="camembert_matcher", device=DEVICE)
-
-    #Prediction
-    ners = [umls_matcher, drbert_matcher, camembert_matcher]
-    predicted_entities = {}
-    for ner in ners:
-        predicted_entities[ner.description.name] = []
-    if use_gpt : predicted_entities['GPT-3.5-turbo'] = []
-
-    # Predict entites for each doc for each NER tool
-    for doc in tqdm(_docs):
-        for ner in ners:
-            entities = ner.run([doc.raw_segment])
-            predicted_entities[ner.description.name].append(entities)
-        if use_gpt:
-            entities = LLMNER(doc.text, nlp)
-            predicted_entities['GPT-3.5-turbo'].append(entities)
-    
     ner_evaluator = SeqEvalEvaluator(return_metrics_by_label=True, average='weighted', labels_remapping=_labels_remapping) 
 
-    # Compute NER metrics for each NER tool
     dfs = []
-    for ner in ners:
-        results = ner_evaluator.compute(_docs, predicted_entities[ner.description.name])
-        dfs.append(results_to_df(_results=results, _title=ner.description.name))
-    if use_gpt:
-        results = ner_evaluator.compute(_docs, predicted_entities['GPTNER'])
-        dfs.append(results_to_df(_results=results, _title='GPTNER'))
 
+    for ner in ners:
+        predicted_entities = [ner.run([doc.raw_segment]) for doc in tqdm(_docs)]
+        results = ner_evaluator.compute(_docs, predicted_entities)
+        dfs.append(results_to_df(_results=results, _title=ner.description.name))
+        
     return pd.concat(dfs, axis=1)
 
-def test(_doc, open_ai_key = "", _labels_remapping = {
-        "ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
-        "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
+#Affiche les annotation de plusieurs outils de NER sur le document fourni
+def test(_doc, open_ai_key="", _labels_remapping={"ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
+                                                  "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
     
-    use_gpt = True if open_ai_key != "" else False
-    
-    if use_gpt:
-        os.environ["OPENAI_API_KEY"] = open_ai_key
-        nlp = assemble("config_gpt.cfg")
+    ners = []
+    ners.append(UMLSMatcher(umls_dir=Path.home() / "src/UMLS", cache_dir=".umls_cache", language="FRE", semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'], lowercase=True, normalize_unicode=True, name="UMLS matcher", output_labels_by_semgroup=_labels_remapping))
+    ners.append(HFEntityMatcher(model="Thibeb/CamemBERT_bio_generalized", name="DrBERT matcher", device=DEVICE))
+    ners.append(HFEntityMatcher(model="Thibeb/DrBERT_generalized", name="CamemBERT-bio matcher", device=DEVICE))
+    if open_ai_key != "" : ners.append(GPT_NER("config_gpt3.cfg", open_ai_key,_name='ChatGPT-3.5-turbo'))
+    if open_ai_key != "" : ners.append(GPT_NER("config_gpt4.cfg", open_ai_key,_name='ChatGPT-4'))
 
-    #Loading entity matchers
-    umls_matcher = UMLSMatcher(
-        umls_dir=Path.home() / "src/UMLS",
-        cache_dir=".umls_cache",
-        language="FRE",
-        semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'],
-        lowercase=True,
-        normalize_unicode=True,
-        name="umls_matcher",
-        output_labels_by_semgroup=_labels_remapping
-    )
-
-    drbert_matcher = HFEntityMatcher(model="Thibeb/CamemBert_bio_generalized", name="drbert_matcher", device=DEVICE)
-    camembert_matcher = HFEntityMatcher(model="Thibeb/DrBert_generalized", name="camembert_matcher", device=DEVICE)
-
-    #Prediction
-    ners = [umls_matcher, drbert_matcher, camembert_matcher]
-    annotated_docs = {}
-
-    # Predict entites for each doc for each NER tool
+    annotated_docs = {'Original':_doc}
     for ner in ners:
+        annotated_docs[ner.description.name] = TextDocument(text=_doc.text)
         entities = ner.run([_doc.raw_segment])
-        annotated_doc = TextDocument(text=_doc.text)
         for ent in entities:
-            annotated_doc.anns.add(ent)
-        annotated_docs[ner.description.name] = annotated_doc
-        
-    if use_gpt:
-        entities = LLMNER(_doc.text, nlp)
-        annotated_doc = TextDocument(text=_doc.text)
-        for ent in entities:
-            annotated_doc.anns.add(ent)
-        annotated_docs['GPT-3.5-turbo'] = annotated_doc
+            annotated_docs[ner.description.name].anns.add(ent)
 
-    html_datas = []
-
-    for ner, doc in annotated_docs.items():
-        displacy_data = medkit_doc_to_displacy(doc)
-        html_data = displacy.render(displacy_data, manual=True, style="ent", jupyter=False)
-        html_datas.append(html_data)
-
-    display(HTML("".join(html_datas)))  
+    html_datas = [f'<h1>{name}</h1>{displacy.render(medkit_doc_to_displacy(doc), manual=True, style="ent", jupyter=False)}' for name, doc in annotated_docs.items()]
+    display(HTML("".join(html_datas)))
 ```
 
 ```{code-cell} ipython3
-docs = list(load_text_documents("datasets/quaero/test.jsonl"))[14:25]
-
-eval(docs[:10])
+#Charge une partie du split de test du corpus QUAERO déja pre-processé
+docs = list(load_text_documents("datasets/quaero/test.jsonl"))[:100]
 ```
 
 ```{code-cell} ipython3
-def eval(_docs, _labels_remapping, )
+#Evalue plusieurs outils de NER et renvoie un tableau de comparaison
+eval(docs)
+```
+
+```{code-cell} ipython3
+#Affiche les annotations de différent outils de NER sur un document du split
+test(docs[12], open_ai_key="")
+```
+
+```{code-cell} ipython3
+
 ```

--- a/docs/examples/ner_evaluation/ner_evalution.md
+++ b/docs/examples/ner_evaluation/ner_evalution.md
@@ -1,0 +1,194 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.16.1
+kernelspec:
+  display_name: .venv
+  language: python
+  name: python3
+---
+
+```{code-cell} ipython3
+from medkit.io.medkit_json import load_text_documents
+from medkit.core.text import TextDocument
+from medkit.text.segmentation import SentenceTokenizer
+from pathlib import Path
+from tqdm import tqdm
+from medkit.text.ner import UMLSMatcher
+from medkit.text.metrics.ner import SeqEvalEvaluator
+import pandas as pd
+from glob import glob
+from medkit.text.ner.hf_entity_matcher import HFEntityMatcher
+import torch
+from medkit.core import Pipeline, DocPipeline, PipelineStep
+from medkit.text.postprocessing import filter_overlapping_entities, DocumentSplitter
+from spacy_llm.util import assemble
+import os 
+from medkit.core.text import Entity, Span
+from spacy import displacy
+from medkit.text.spacy.displacy_utils import medkit_doc_to_displacy
+import random
+from IPython.display import display, HTML
+import pandas as pd
+
+DEVICE = 0 if torch.cuda.is_available() else -1
+
+def results_to_df(_results, _title):
+    results_list = list(_results.items())
+    arranged_results = {}
+    arranged_results["Entities"] = ['P','R','F1']
+    arranged_results["all"] = [round(results_list[i][1],2) for i in [0,1,2]]
+    accuracy = round(results_list[4][1],2)
+    for i in range(5,len(results_list), 4):
+        key = results_list[i][0][:-10]
+        arranged_results[key] = [round(results_list[n][1],2) for n in [i,i+1,i+2]]
+    df = pd.DataFrame(arranged_results, index=[f"{_title} ({accuracy})",'','']).T
+    return df
+
+def LLMNER(_text, _nlp):
+    doc = _nlp(_text)
+    
+    predicted_entities = []
+
+    gpt_remapping = {
+    "Anatomie": "ANAT",
+    "Médicament": "CHEM",
+    "Appareil": "DEVI",
+    "Pathologie": "DISO",
+    "Région": "GEOG",
+    "Organisme": "LIVB",
+    "Objet": "OBJC",
+    "Phénomène": "PHEN",
+    "Physiologie": "PHYS",
+    "Procédure": "PROC",
+    }
+
+    for ent in doc.ents:
+        predicted_entities.append(Entity(
+            label=gpt_remapping[ent.label_],
+            text=ent.text,
+            spans=[Span(ent.start_char, ent.end_char)]
+        ))
+
+    return predicted_entities
+
+def eval(_docs, open_ai_key = "", _labels_remapping = {
+        "ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
+        "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
+
+    use_gpt = True if open_ai_key != "" else False
+    
+    if use_gpt:
+        os.environ["OPENAI_API_KEY"] = open_ai_key
+        nlp = assemble("config_gpt.cfg")
+
+    #Loading entity matchers
+    umls_matcher = UMLSMatcher(
+        umls_dir=Path.home() / "src/UMLS",
+        cache_dir=".umls_cache",
+        language="FRE",
+        semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'],
+        lowercase=True,
+        normalize_unicode=True,
+        name="umls_matcher",
+        output_labels_by_semgroup=_labels_remapping
+    )
+
+    drbert_matcher = HFEntityMatcher(model="Thibeb/CamemBert_bio_generalized", name="drbert_matcher", device=DEVICE)
+    camembert_matcher = HFEntityMatcher(model="Thibeb/DrBert_generalized", name="camembert_matcher", device=DEVICE)
+
+    #Prediction
+    ners = [umls_matcher, drbert_matcher, camembert_matcher]
+    predicted_entities = {}
+    for ner in ners:
+        predicted_entities[ner.description.name] = []
+    if use_gpt : predicted_entities['GPT-3.5-turbo'] = []
+
+    # Predict entites for each doc for each NER tool
+    for doc in tqdm(_docs):
+        for ner in ners:
+            entities = ner.run([doc.raw_segment])
+            predicted_entities[ner.description.name].append(entities)
+        if use_gpt:
+            entities = LLMNER(doc.text, nlp)
+            predicted_entities['GPT-3.5-turbo'].append(entities)
+    
+    ner_evaluator = SeqEvalEvaluator(return_metrics_by_label=True, average='weighted', labels_remapping=_labels_remapping) 
+
+    # Compute NER metrics for each NER tool
+    dfs = []
+    for ner in ners:
+        results = ner_evaluator.compute(_docs, predicted_entities[ner.description.name])
+        dfs.append(results_to_df(_results=results, _title=ner.description.name))
+    if use_gpt:
+        results = ner_evaluator.compute(_docs, predicted_entities['GPTNER'])
+        dfs.append(results_to_df(_results=results, _title='GPTNER'))
+
+    return pd.concat(dfs, axis=1)
+
+def test(_doc, open_ai_key = "", _labels_remapping = {
+        "ANAT": "ANAT", "CHEM": "CHEM", "DEVI": "DEVI", "DISO": "DISO", "GEOG": "GEOG",
+        "LIVB": "LIVB", "OBJC": "OBJC", "PHEN": "PHEN", "PHYS": "PHYS", "PROC": "PROC",}):
+    
+    use_gpt = True if open_ai_key != "" else False
+    
+    if use_gpt:
+        os.environ["OPENAI_API_KEY"] = open_ai_key
+        nlp = assemble("config_gpt.cfg")
+
+    #Loading entity matchers
+    umls_matcher = UMLSMatcher(
+        umls_dir=Path.home() / "src/UMLS",
+        cache_dir=".umls_cache",
+        language="FRE",
+        semgroups=['ANAT', 'CHEM', 'DEVI', 'DISO', 'GEOG', 'LIVB', 'OBJC', 'PHEN', 'PHYS', 'PROC'],
+        lowercase=True,
+        normalize_unicode=True,
+        name="umls_matcher",
+        output_labels_by_semgroup=_labels_remapping
+    )
+
+    drbert_matcher = HFEntityMatcher(model="Thibeb/CamemBert_bio_generalized", name="drbert_matcher", device=DEVICE)
+    camembert_matcher = HFEntityMatcher(model="Thibeb/DrBert_generalized", name="camembert_matcher", device=DEVICE)
+
+    #Prediction
+    ners = [umls_matcher, drbert_matcher, camembert_matcher]
+    annotated_docs = {}
+
+    # Predict entites for each doc for each NER tool
+    for ner in ners:
+        entities = ner.run([_doc.raw_segment])
+        annotated_doc = TextDocument(text=_doc.text)
+        for ent in entities:
+            annotated_doc.anns.add(ent)
+        annotated_docs[ner.description.name] = annotated_doc
+        
+    if use_gpt:
+        entities = LLMNER(_doc.text, nlp)
+        annotated_doc = TextDocument(text=_doc.text)
+        for ent in entities:
+            annotated_doc.anns.add(ent)
+        annotated_docs['GPT-3.5-turbo'] = annotated_doc
+
+    html_datas = []
+
+    for ner, doc in annotated_docs.items():
+        displacy_data = medkit_doc_to_displacy(doc)
+        html_data = displacy.render(displacy_data, manual=True, style="ent", jupyter=False)
+        html_datas.append(html_data)
+
+    display(HTML("".join(html_datas)))  
+```
+
+```{code-cell} ipython3
+docs = list(load_text_documents("datasets/quaero/test.jsonl"))[14:25]
+
+eval(docs[:10])
+```
+
+```{code-cell} ipython3
+def eval(_docs, _labels_remapping, )
+```


### PR DESCRIPTION
# Notebook instantiating multiple entity matchers : 
- UMLS matcher
- DrBert HF matcher finetuned on the QUAERO, E3C, CASM2 corpus 
- CamemBert-bio HF matcher finetuned on the QUAERO, E3C, CASM2 corpus
- GPT 3.5-turbo and 4 entity matcher using the spacy-llm library

# Two functions are available : 
- eval() which instantiate, match, and evaluate every entity matchers on the provided docs
- test() which instantiate, match and show the annotations of every matchers on the provided doc

# GPT entity matching using spacy-llm :
- config_gpt3.cfg is the configuration file for the spacy-llm NER using the GPT-3.5-turbo model
- config_gpt4.cfg is the same as above but with the GPT-4 model
- examples.json is a file used by spacy-llm when instantiating NLP NER models to give some examples following the Chain of thoughts principle