### PR TITLE
CI: Run tests on macos-13 instead of macos-latest

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -22,8 +22,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest ]
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        include:
+          - os: macos-13
+            python-version: '3.11'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5


### PR DESCRIPTION
`macos-latest` is scheduled to jump from 12 to 14 and to switch from Intel to ARM. `macos-13` sould be the last runner on Intel. To avoid accidental regressions, set the macOS runner to `macos-13`.