### PR TITLE
CI: Run tests for macOS on Python 3.12

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,25 +26,15 @@ jobs:
         python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
         include:
           - os: macos-13
-            python-version: '3.11'
+            python-version: '3.12'
           - os: macos-14
-            python-version: '3.11'
+            python-version: '3.12'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
-      # see https://github.com/actions/runner-images/issues/9256
-      - name: Fix pipx permissions
-        if: matrix.os == 'macos-14'
-        run: |
-          for d in "$PIPX_HOME" "$PIPX_BIN_DIR" ; do
-            if [[ -n "$d" ]] ; then
-              sudo mkdir -p "$d"
-              sudo chown -R $(id -u) "$d"
-            fi
-          done
       - name: Install Hatch
         run: pipx install hatch
       - name: Run tests


### PR DESCRIPTION
Tests on Python 3.8 to 3.11 will fail due to https://github.com/scossin/iamsystem_python/pull/24