### PR TITLE
CI: Update Python versions used for testing and building the docs

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: pip
       - name: Install Hatch
         uses: pypa/hatch@install

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,12 +23,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest ]
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13' ]
         include:
-          - os: macos-13
-            python-version: '3.12'
           - os: macos-14
-            python-version: '3.12'
+            python-version: '3.13'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5

--- a/hatch.toml
+++ b/hatch.toml
@@ -26,7 +26,7 @@ dependencies = [
 cov = "pytest --cov-config=pyproject.toml {args}"
 no-cov = "cov --no-cov {args}"
 [[envs.test.matrix]]
-python = ["3.8", "3.9", "3.10", "3.11", "3.12"]
+python = ["3.9", "3.10", "3.11", "3.12", "3.13"]
 
 [envs.types]
 dependencies = ["mypy"]

--- a/hatch.toml
+++ b/hatch.toml
@@ -2,7 +2,7 @@
 packages = ["medkit"]
 
 [envs.docs]
-python = "3.11"
+python = "3.12"
 features = [
   "deid",
   "docs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Medical Science Apps.",
   "Topic :: Software Development",


### PR DESCRIPTION
- Linux: drop 3.8, add 3.13
- macOS: use 3.13
- docs: use 3.12